### PR TITLE
Support filelist generation on OS X

### DIFF
--- a/filelist.sh
+++ b/filelist.sh
@@ -7,11 +7,24 @@ outFile="./src/resources/filelist.h"
 count_old=$(cat $outFile 2>/dev/null | tr -d '\n\n' | sed 's/[^0-9]*\([0-9]*\).*/\1/')
 
 count=0
+if [[ $OSTYPE == darwin* ]]; 
+then 
+
+for i in $(gfind ./data/images/ ./data/sounds/ ./data/fonts/ -maxdepth 1 -type f  \( ! -printf "%f\n" \) | sort -f)
+do
+	files[count]=$i
+	count=$((count+1))
+done
+
+else
+
 for i in $(find ./data/images/ ./data/sounds/ ./data/fonts/ -maxdepth 1 -type f  \( ! -printf "%f\n" \) | sort -f)
 do
 	files[count]=$i
 	count=$((count+1))
 done
+
+fi
 
 if [ "$count_old" != "$count" ] || [ ! -f $outFile ]
 then


### PR DESCRIPTION
The find command OS X ships with does not support -printf, which currently results in resources not being included. filelist.sh now uses GNU find, which solves this problem.  

It requires findutils to be installed, which can be done easily with Homebrew (e.g. `brew install findutils)` for example.