### PR TITLE
Fixed guiIconGrip selected game, displayed page and arrows

### DIFF
--- a/src/gui/GuiIconGrid.cpp
+++ b/src/gui/GuiIconGrid.cpp
@@ -49,11 +49,11 @@ GuiIconGrid::GuiIconGrid(int w, int h, int GameIndex)
     , arrowRightButton(arrowRightImage.getWidth(), arrowRightImage.getHeight())
     , arrowLeftButton(arrowLeftImage.getWidth(), arrowLeftImage.getHeight())
 {
-    listOffset = 0;
     gameLaunchTimer = 0;
     selectedGame = GameIndex;
-    currentLeftPosition = 0;
-    targetLeftPosition = 0;
+    listOffset = selectedGame / (MAX_COLS * MAX_ROWS);
+    targetLeftPosition = -listOffset * getWidth();
+    currentLeftPosition = targetLeftPosition;
 
     particleBgImage.setParent(this);
 
@@ -126,6 +126,8 @@ GuiIconGrid::GuiIconGrid(int w, int h, int GameIndex)
         arrowLeftButton.setTrigger(&buttonLTrigger);
         arrowLeftButton.setSoundClick(buttonClickSound);
         arrowLeftButton.clicked.connect(this, &GuiIconGrid::OnLeftArrowClick);
+        if(listOffset > 0)
+            append(&arrowLeftButton);
 
         arrowRightButton.setImage(&arrowRightImage);
         arrowRightButton.setEffectGrow();
@@ -136,7 +138,8 @@ GuiIconGrid::GuiIconGrid(int w, int h, int GameIndex)
         arrowRightButton.setTrigger(&buttonRTrigger);
         arrowRightButton.setSoundClick(buttonClickSound);
         arrowRightButton.clicked.connect(this, &GuiIconGrid::OnRightArrowClick);
-        append(&arrowRightButton);
+        if(listOffset < (maxPages-1))
+            append(&arrowRightButton);
     }
 
     gameTitle.setPosition(0, -320);

--- a/src/menu/MainWindow.cpp
+++ b/src/menu/MainWindow.cpp
@@ -184,6 +184,9 @@ void MainWindow::drawTv(CVideo *video)
 
 void MainWindow::SetupMainView()
 {
+    if(CSettings::getValueAsU16(CSettings::GameStartIndex) > GameList::instance()->size())
+        CSettings::setValueAsU16(CSettings::GameStartIndex,0);
+
     switch(CSettings::getValueAsU8(CSettings::GameViewModeTv))
     {
         case VIEW_ICON_GRID: {


### PR DESCRIPTION
Bugs introduced by the GameStartIndex (last selected game) by
@FunThomas76.
Anyway there still some bugs/issues (if value is upper than amount of
games, after some games deletion from the SD...). At the end I think it
would be better to set it to 0 at loadiine startup and keep last
selected game feature only when entering/exiting setings menu. I let you
see.

Edit: or verify if GameStartIndex is upper than GameList::instance()->size() in MainWindow. Then set GameStartIndex to 0 (or to GameList::instance()->size() ) if true.

Edit2: I have finally implemented it by my second commit below.