### PR TITLE
Added description for PyGecko and Padcon in settings menu

### DIFF
--- a/src/menu/SettingsMenu.cpp
+++ b/src/menu/SettingsMenu.cpp
@@ -50,7 +50,7 @@ stSettingsCategories[] =
 {
     { trNOOP("GUI"),     "guiSettingsIcon.png",    "guiSettingsIconGlow.png",    trNOOP("Game View Selection") "\n" trNOOP("Background customizations") },
     { trNOOP("Loader"),  "loaderSettingsIcon.png", "loaderSettingsIconGlow.png", trNOOP("Customize games path") "\n" trNOOP("Customize save path") "\n" trNOOP("Set save mode") },
-    { trNOOP("Game"),    "gameSettingsIcon.png",   "gameSettingsIconGlow.png",   trNOOP("Launch method selection") "\n" trNOOP("Log server control") "\n" trNOOP("Adjust log server IP and port") },
+    { trNOOP("Game"),    "gameSettingsIcon.png",   "gameSettingsIconGlow.png",   trNOOP("Launch method selection") "\n" trNOOP("Log server control") "\n" trNOOP("Adjust log server IP and port") "\n" trNOOP("PyGecko settings") "\n" trNOOP("Padcon settings")},
     { trNOOP("Credits"), "creditsIcon.png",        "creditsIconGlow.png",        trNOOP("Credits to all contributors") }
 };
 


### PR DESCRIPTION
Hi, i added a small fix for the settings menu. In the game settings top menu item there were no description about changing settings for PyGecko and padcon.