### PR TITLE
Get ID6 from meta/meta.xml as fallback

### DIFF
--- a/src/game/GameList.cpp
+++ b/src/game/GameList.cpp
@@ -6,6 +6,7 @@
 #include "common/common.h"
 #include "settings/CSettings.h"
 #include "fs/DirList.h"
+#include "utils/xml.h"
 
 GameList *GameList::gameListInstance = NULL;
 
@@ -47,17 +48,28 @@ int GameList::readGameList()
     for(int i = 0; i < dirList.GetFilecount(); i++)
     {
         const char *filename = dirList.GetFilename(i);
+        char id6[7];
         int len = strlen(filename);
-        if (len <= 8)
-            continue;
 
-        if ((filename[len - 8] != '[' && filename[len - 6] != '[') || filename[len - 1] != ']')
+        discHeader newHeader;
+
+        if (len <= 8 ||
+                ((filename[len - 8] != '[' && filename[len - 6] != '[') || filename[len - 1] != ']'))
+        {
+            if (GetId6FromMeta((gamePath + "/" + filename + META_PATH).c_str(), id6) == 0)
+            {
+                newHeader.id = id6;
+                newHeader.name = filename;
+                newHeader.gamepath = gamePath + "/" + filename;
+
+                fullGameList.push_back(newHeader);
+            }
             continue;
+        }
 
         bool id4Title = (filename[len - 8] != '[');
 
         std::string gamePathName = filename;
-        discHeader newHeader;
         if(id4Title)
         {
             newHeader.id = gamePathName.substr(gamePathName.size() - 5, 4);

--- a/src/utils/xml.c
+++ b/src/utils/xml.c
@@ -242,3 +242,45 @@ int LoadXmlParameters(ReducedCosAppXmlInfo * xmlInfo, const char *rpx_name, cons
 
     return 0;
 }
+
+int GetId6FromMeta(const char *path, char *id6)
+{
+    id6[0] = 0;
+    char* path_copy = (char*)malloc(FS_MAX_MOUNTPATH_SIZE);
+    if (!path_copy)
+        return -1;
+
+    char* xmlNodeData = (char*)malloc(XML_BUFFER_SIZE);
+    if(!xmlNodeData) {
+        free(path_copy);
+        return -3;
+    }
+
+    // create path
+    snprintf(path_copy, FS_MAX_MOUNTPATH_SIZE, "%s/meta.xml", path);
+
+    char* xmlData = NULL;
+    u32 xmlSize = 0;
+
+    if(LoadFileToMem(path_copy, (u8**) &xmlData, &xmlSize) > 0)
+    {
+        // ensure 0 termination
+        xmlData[XML_BUFFER_SIZE-1] = 0;
+
+        if(XML_GetNodeText(xmlData, "product_code", xmlNodeData, XML_BUFFER_SIZE) && strlen(xmlNodeData) == 10)
+            strncpy(id6, xmlNodeData + 6, 4);
+        if(XML_GetNodeText(xmlData, "company_code", xmlNodeData, XML_BUFFER_SIZE) && strlen(xmlNodeData) == 4)
+            strncpy(id6 + 4, xmlNodeData + 2, 2);
+
+        id6[6] = 0;
+    }
+
+    free(xmlData);
+    free(xmlNodeData);
+    free(path_copy);
+
+    if(strlen(id6) == 6)
+        return 0;
+    else
+        return -2;
+}

--- a/src/utils/xml.h
+++ b/src/utils/xml.h
@@ -9,6 +9,7 @@ extern "C" {
 
 char * XML_GetNodeText(const char *xml_part, const char * nodename, char * output, int output_size);
 int LoadXmlParameters(ReducedCosAppXmlInfo * xmlInfo, const char *rpx_name, const char *path);
+int GetId6FromMeta(const char *path, char *output);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Since I hate to have the Title ID in directory name and since you have the needed informations in meta/meta.xml (if it's a proper dump made with ddd, extracted from WUD or downloaded and decrypted from NUS) I implemented the read of meta/meta.xml as fallback in order to extract the ID6 and the name.

Obviously I'm not changing the default behaviour, this works only if you don't have the ~~legacy~~ default directory naming